### PR TITLE
Fix geocoding to be a little more strict

### DIFF
--- a/src/data/geocoding_util.py
+++ b/src/data/geocoding_util.py
@@ -68,7 +68,7 @@ def write_geocode_cache(results,
             writer.writerow([key, value[0], value[1], value[2], value[3]])
 
 
-def lookup_address(intersection, cached, mapboxtoken=None):
+def lookup_address(intersection, cached, mapboxtoken=None, city=None, strict=False):
     """
     Look up an intersection first in the cache, and if it
     doesn't exist, geocode it
@@ -76,21 +76,26 @@ def lookup_address(intersection, cached, mapboxtoken=None):
     Args:
         intersection: string
         cached: dict
+        mapboxtoken: optional, but needed if you want to use mapbox's geocoding
     Returns:
         tuple of original address, geocoded address, latitude, longitude
     """
 
     # If we've cached this either successfully or were unable to find
     # the address previously
+    if city:
+        city = city.split(',')[0]
     if intersection in list(cached.keys()) and cached[intersection][3]:
         print(intersection + ' is cached')
         return cached[intersection]
     else:
         print('geocoding ' + intersection)
-        return list(geocode_address(intersection, {}, mapboxtoken))
+        return list(geocode_address(
+            intersection, {}, mapboxtoken=mapboxtoken, city=city, strict=strict))
 
 
-def geocode_address(address, cached={}, mapboxtoken=None):
+def geocode_address(address, cached={}, mapboxtoken=None, strict=False,
+                    city=None):
     """
     Check an optional cache to see if we already have the geocoded address
     Otherwise, use google's API to look up the address
@@ -100,21 +105,37 @@ def geocode_address(address, cached={}, mapboxtoken=None):
     Args:
         address
         cached (optional)
+        mapboxtoken (optional), uses arcgis if not given
+        strict (optional): be more particular about whether mapbox results are good enough
+        city (optional): limits results to given city
     Returns:
         address, latitude, longitude, status
     """
 
     if address in list(cached.keys()):
         return cached[address]
+
+    result_found = False
     if mapboxtoken:
         g = geocoder.mapbox(address, key=mapboxtoken)
-    else:
+        if g.status == 'OK':
+            result_found = True
+            
+        # When mapbox can't find the address, it will default to city name
+        # If strict flag is on, we don't want to use those results
+        # Also sometimes mapbox doesn't find the address in this city
+        # and picks a different city. Don't want those either
+        if strict and city and (
+                g.address.startswith(city)
+                or city not in g.address
+        ):
+            result_found = False
+
+    # If there was no appropriate result from mapbox, try with arcgis
+    if not result_found:
         g = geocoder.arcgis(address)
-    attempts = 0
-    while g.address is None and attempts < 3:
-        attempts += 1
-        sleep(attempts ** 2)
-        g = geocoder.google(address)
+    if g.address == 'Somerville, Massachusetts, United States':
+        __import__("ipdb").set_trace()
 
     status = ''
 

--- a/src/tools/geocode_batch.py
+++ b/src/tools/geocode_batch.py
@@ -20,7 +20,7 @@ def parse_addresses(directory, filename, city, addressfield,
         for r in csv_reader:
             address = r[addressfield] + ' ' + city
             geocoded_add, lat, lng, status = lookup_address(
-                address, cached, mapboxtoken=mapboxtoken)
+                address, cached, mapboxtoken=mapboxtoken, city=city, strict=True)
             cached[address] = [geocoded_add, lat, lng, status]
 
             if status == 'S':


### PR DESCRIPTION
- Mapbox is pretty good but occasionally makes some mistakes. There are two typical possibilities: if you're geocoding in a specific city and mapbox can't find the address it might give you a result from a different city. Or if it can't find the address it will default to just the center point of the city. In both those cases, fall back to using arcgis
- Google no longer allows use of geocoding api without an account with a linked payment. So removing that as an option to geocode