### PR TITLE
Generalizing point base features, a few other fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        auto-update-conda: false
+        auto-update-conda: true
         activate-environment: crash-model
         environment-file: conda-osx-64.lock
         channels: conda-forge, defaults

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,8 @@ jobs:
         auto-update-conda: false
         activate-environment: crash-model
         environment-file: conda-osx-64.lock
+        channels: conda-forge, defaults
+        channel-priority: strict
     - name: Run mac tests
       run: |
         set -eo pipefail

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
   mac:
     env:
       PYTHONFAULTHANDLER: "true"
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -1,4 +1,4 @@
-name: crash-model
+name: crash-model_2
 channels:
   - conda-forge
   - defaults
@@ -177,7 +177,7 @@ dependencies:
   - seaborn-base=0.10.1=py_1
   - send2trash=1.5.0=py_0
   - setuptools=47.3.1=py36h9f0ad1d_0
-  - shapely=1.6.4
+  - shapely=1.6.4=py36h5c88e11_1006
   - sip=4.19.8=py36h0a44026_1000
   - six=1.15.0=pyh9f0ad1d_0
   - sqlite=3.30.1=h93121df_0

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -1,4 +1,4 @@
-name: crash-model_2
+name: crash-model
 channels:
   - conda-forge
   - defaults

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -177,7 +177,7 @@ dependencies:
   - seaborn-base=0.10.1=py_1
   - send2trash=1.5.0=py_0
   - setuptools=47.3.1=py36h9f0ad1d_0
-  - shapely=1.6.4.post2
+  - shapely=1.6.4
   - sip=4.19.8=py36h0a44026_1000
   - six=1.15.0=pyh9f0ad1d_0
   - sqlite=3.30.1=h93121df_0

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -177,7 +177,7 @@ dependencies:
   - seaborn-base=0.10.1=py_1
   - send2trash=1.5.0=py_0
   - setuptools=47.3.1=py36h9f0ad1d_0
-  - shapely=1.6.4=py36h5c88e11_1006
+  - shapely=1.6.4.post2
   - sip=4.19.8=py36h0a44026_1000
   - six=1.15.0=pyh9f0ad1d_0
   - sqlite=3.30.1=h93121df_0

--- a/src/README.md
+++ b/src/README.md
@@ -45,11 +45,18 @@ If you'd prefer to run the pipeline on any of our demo cities, you can access th
     - Supplemental files are optional: any number of csv files that contain a lat/lon point and some type of feature you'd like to extract
 
 - Once you have run the initialize_city script, you need to manually edit the configuration file found in e.g. src/config/config_cambridge:
-        - If OpenStreetMaps does not have polygon data for your city, the road network will need to be constructed manually. Set the city_latitude and city_longitude values to the centerpoint of the city, and the city_radius to an appropriate distance (in km) that you would like the road network to be built for, e.g 15 for 15km radius from the specified lat / lng.
-        - For your csv crash file, enter the column header for id, latitude, longitude, and date.  If time is in a different column than date, give that column header as well. If your csv file does not contain an id field, just put ID here, and the csv will be modified to add an ID
-        - If you have any supplemental files, they will be listed under data_source. For each data source, you'll need to enter the column headers for latitude, longitude, and date.
-        - Modify time_target to be the last month and year of your crash data (this is legacy and you won't need to do this unless you want to do week-by-week modeling)
-        - We also allow you to specify addditional features in the crash file to include in the training data set. This has been designed to handle mode (pedestrian, bike, vehicle) but designed to handle any set of features in the crash file. Here is an example of how to handle mode if it is specified as a single column with different value for each mode
+  - If OpenStreetMaps does not have polygon data for your city:
+    - Set the city_latitude and city_longitude values to the centerpoint of the city
+    - Set the city_radius to an appropriate distance (in km) that you would like the road network to be built for, e.g 15 for 15km radius from the centerpoint lat / lng.
+  - For the crash file configuration section
+    - Enter the column name for id, latitude, longitude, and date
+      - If your csv file does not contain an id field, just put ID here, and the csv will be modified to add an ID
+    - If time is in a different column than date, give that column header as well. 
+  - If you have any supplemental files (point based features)
+    - Refer to the section on [point based features](https://github.com/insight-lane/crash-model/tree/master/src#point-based-features)
+  - Modify time_target to be the last month and year of your crash data (this is legacy and you won't need to do this unless you want to do week-by-week modeling)
+  - Specify addditional crash features in the crash file to include in the training data set
+    - This has been designed to handle mode (pedestrian, bike, vehicle) but designed to handle any set of features in the crash file. Here is an example of how to handle mode if it is specified as a single column with different value for each mode
 
 ```
       split_columns:
@@ -131,7 +138,38 @@ If you have set split columns in the config .yml file, you can select which spli
 
 Details about other visualization scripts can be found in the README under src/visualization
 
-### Running on existing cities
+## Point-based features
+- If you have additional features for the model that have lat/lon or addresses, you can add them in the `data_source` section
+- For each file, you need to provide location info (either lat/long or address) and _at least_ a year value
+- For each feature in that file, provide feature details
+  - name (required) - feature name
+  - feat_type - feature is 'categorical' or 'continuous' (numeric), default is continuous 
+  - feat_agg (feature aggregation) - only option is 'latest' (latest value), default is count
+    - count - the number of instances of that location, example: concerns reported
+    - latest - if you just want one value per location, will take the latest based on date
+      - This is useful for segment-specific features that exist with, e.g. crash data
+  - value (required if using feat_agg = 'latest') - column name having the value for the feature  
+  - supplemental (not used in pipeline currently)
+    - category - column name with category information 
+    - notes - notes column
+  
+Example: 
+```
+data_source:
+  - filename: example.csv
+    latitude: lat
+    longitude: lon
+    date: date_col
+    feats:
+      - name: road_type
+        feat_agg: latest # will get latest value at lat/long
+        value: RAW_ROAD_TYPE_COL
+        feat_type: categorical # road type is a categorical feature
+      - name: concerns # will default to count at lat/long
+```
+
+
+## Running on existing cities
 - Cities we have already set up on the showcase can be viewed using the default configuration file. If you'd prefer to view these cities, use that configuration file instead: `export CONFIG_FILE=static/config.js'
 
 

--- a/src/data/config.py
+++ b/src/data/config.py
@@ -80,7 +80,7 @@ class Configuration(object):
             if 'optional' in crash_value and 'split_columns' in crash_value['optional']:
                 self.split_columns += crash_value['optional']['split_columns'].keys()
 
-    def __get_feature_type(self, feat: dict) -> str:
+    def _get_feature_type(self, feat: dict) -> str:
         """
         Gets the feature type for feature, defaults to continuous
         Args:
@@ -128,9 +128,9 @@ class Configuration(object):
                 # for multiple features per file, different processing
                 if 'feats' in additional:
                     for feat in additional['feats']:
-                        feat_types[self.__get_feature_type(feat)].append(feat['name'])
+                        feat_types[self._get_feature_type(feat)].append(feat['name'])
                     continue
-                feat_types[self.__get_feature_type(additional)].append(additional['name'])
+                feat_types[self._get_feature_type(additional)].append(additional['name'])
 
         # May eventually want to rename this feature to be more general
         # For now, all atr features are continuous

--- a/src/data/create_segments.py
+++ b/src/data/create_segments.py
@@ -328,7 +328,7 @@ def add_point_based_features(non_inters: list, inters: list,
         feat_type = feature.properties['feature']
         feat_agg_type = ""
 
-        if 'feat_agg' in feature.properties and 'value' in feature.properties:
+        if 'feat_agg' in feature.properties:
             feat_agg_type = feature.properties['feat_agg']
             date = feature.properties['date']
 
@@ -337,8 +337,14 @@ def add_point_based_features(non_inters: list, inters: list,
                 matches[str(near)] = {}
 
             # only accepts "latest value", otherwise just count
-            if feat_agg_type == 'latest':  
-                aggregation_values[(str(near), feat_type)][date] = feature.properties['value']
+            if feat_agg_type == 'latest':
+                try:
+                    if 'value' in feature.properties:
+                        aggregation_values[(str(near), feat_type)][date] = feature.properties['value']
+                    elif 'category' in feature.properties:
+                        aggregation_values[(str(near), feat_type)][date] = feature.properties['category']
+                except KeyError as e:
+                    raise KeyError(f"feature_agg 'latest' specified but no value in key {e}")
             else:
                 if feat_type not in matches[str(near)]:
                     matches[str(near)][feat_type] = 0

--- a/src/data/create_segments.py
+++ b/src/data/create_segments.py
@@ -278,7 +278,8 @@ def find_non_ints(roads, int_buffers):
     return non_int_lines, inter_segments
 
 
-def add_point_based_features(non_inters, inters, jsonfile,
+def add_point_based_features(non_inters: list, inters: list,
+                             jsonfile: str,
                              feats_filename=None,
                              additional_feats_filename=None,
                              forceupdate=False):
@@ -286,8 +287,8 @@ def add_point_based_features(non_inters, inters, jsonfile,
     Add any point-based set of features to existing segment data.
     If it isn't already attached to the segments
     Args:
-        non_inters
-        inters
+        non_inters - list of non-intersection segments
+        inters - list of intersection segments
         jsonfile - points_joined.json, storing the results of snapping
         feats_filename - geojson file for point-based features data
         addtiional_feats_filename (optional) - file for additional
@@ -335,6 +336,7 @@ def add_point_based_features(non_inters, inters, jsonfile,
             if str(near) not in matches:
                 matches[str(near)] = {}
 
+            # only accepts "latest value", otherwise just count
             if feat_agg_type == 'latest':  
                 aggregation_values[(str(near), feat_type)][date] = feature.properties['value']
             else:

--- a/src/data/make_dataset.py
+++ b/src/data/make_dataset.py
@@ -106,7 +106,7 @@ if __name__ == '__main__':
             '-n',
             outputdir
         ] + (['--forceupdate'] if recreate else []))
-        # Create segments from the Boston data
+
         subprocess.check_call([
             'python',
             '-m',
@@ -122,8 +122,7 @@ if __name__ == '__main__':
                 DATA_FP, 'processed', 'maps', outputdir, 'elements.geojson')
         ] + (['--forceupdate'] if recreate else []))
 
-        # Map the boston segments to the open street map segments
-        # and add features
+        # Map the additional map segments to the open street map segments
         subprocess.check_call([
             'python',
             '-m',

--- a/src/data/tests/test_config.py
+++ b/src/data/tests/test_config.py
@@ -81,3 +81,18 @@ def test_get_feature_list(tmpdir):
     assert config.continuous_features == ['AADT']
     assert set(config.features) == set([
         'SPEEDLIMIT', 'Struct_Cnd', 'Surface_Tp', 'F_F_Class', 'AADT'])
+
+    config_dict['data_source'] = [
+        {'filename': 'test_multi',
+        'feats': [
+            {'name': 'cat_test',
+            'feat_type': 'categorical'},
+            {'name': 'cont_test',
+             'feat_type': 'continuous'},
+            {'name': 'default_test'},
+         ]}]
+
+    write_to_file(yml_file, config_dict)
+    config = data.config.Configuration(yml_file)
+    assert all([c in config.continuous_features for c in ['cont_test', 'default_test']])
+    assert 'cat_test' in config.categorical_features

--- a/src/data/util.py
+++ b/src/data/util.py
@@ -409,7 +409,7 @@ def write_records_to_geojson(records, outfilename):
 
     records = prepare_geojson(records)
     with open(outfilename, 'w') as outfile:
-        geojson.dump(records, outfile)
+        geojson.dump(records, outfile, allow_nan=True)
     return records
 
 
@@ -560,7 +560,7 @@ def output_from_shapes(items, filename):
         })
 
     with open(filename, 'w') as outfile:
-        geojson.dump(geojson.FeatureCollection(output), outfile)
+        geojson.dump(geojson.FeatureCollection(output), outfile, allow_nan=True)
 
 
 def write_segments(non_inters, inters, mapfp):
@@ -586,6 +586,6 @@ def write_segments(non_inters, inters, mapfp):
     segments = non_inters['features'] + int_w_ids['features']
 
     with open(os.path.join(mapfp, 'inter_and_non_int.geojson'), 'w') as outfile:
-        geojson.dump(geojson.FeatureCollection(segments), outfile)
+        geojson.dump(geojson.FeatureCollection(segments), outfile, allow_nan=True)
 
 

--- a/src/data_standardization/standardization_util.py
+++ b/src/data_standardization/standardization_util.py
@@ -5,7 +5,7 @@ from jsonschema import validate
 from dateutil import tz
 
 
-def parse_date(date, timezone, time=None, time_format=None):
+def parse_date(date: str, timezone: str, time=None, time_format=None):
     """
     Turn a date (and optional time) into a datetime string
     in standardized format

--- a/src/data_standardization/standardize_crashes.py
+++ b/src/data_standardization/standardize_crashes.py
@@ -32,12 +32,13 @@ def validate_coords(crash: dict, lat_field: str, lon_field: str):
             lat = float(crash[lat_field])
             lon = float(crash[lon_field])
         except ValueError:
-            return None, None
+            return
         if abs(lat) > 90:
-            return None, None
+            return
         if abs(lon) > 180:
-            return None, None
+            return
         return lat, lon
+
 
 
 
@@ -83,9 +84,11 @@ def read_standardized_fields(raw_crashes: dict, fields: dict, opt_fields: dict,
         if i % 10000 == 0:
             print(i)
 
-        lat, lon = validate_coords(crash, fields['latitude'], fields['longitude'])
+        lat_lon = validate_coords(crash, fields['latitude'], fields['longitude'])
+        if lat_lon:
+            lat, lon = lat_lon
 
-        if not lat or not lon:
+        else:
             # skip any crashes that don't have coordinates
             if 'address' not in opt_fields or opt_fields['address'] not in crash:
                 continue

--- a/src/data_standardization/standardize_crashes.py
+++ b/src/data_standardization/standardize_crashes.py
@@ -88,17 +88,21 @@ def read_standardized_fields(raw_crashes, fields, opt_fields,
             else:
                 crash_date = crash[fields["date_complete"]]
 
-        elif fields["date_year"] and fields["date_month"]:
+        elif fields["date_year"]:
+            # TODO: generally, we don't need date anymore, we should remove it
+            # for now, month is always january if unspecified
+            date_month = 1
+            date_year = int(crash[fields["date_year"]])
+            if fields["date_month"]:
+                date_month = int(crash[fields["date_month"]])
             if fields["date_day"]:
-                crash_date = str(crash[fields["date_year"]]) + "-" + str(
-                    crash[fields["date_month"]]) + "-" + crash[fields["date_day"]]
+                crash_date = f'{date_year}-{date_month}-{crash[fields["date_day"]]}'
             # some cities do not supply a day of month for crashes, randomize if so
             else:
                 available_dates = calendar.Calendar().itermonthdates(
-                    crash[fields["date_year"]], crash[fields["date_month"]])
+                    date_year, date_month)
                 crash_date = str(random.choice(
-                    [date for date in available_dates if date.month == crash[fields["date_month"]]]))
-
+                    [date for date in available_dates if date.month == date_month]))
         # skip any crashes that don't have a date
         else:
             continue

--- a/src/data_standardization/standardize_point_data.py
+++ b/src/data_standardization/standardize_point_data.py
@@ -9,19 +9,55 @@ CURR_FP = os.path.dirname(
     os.path.abspath(__file__))
 BASE_FP = os.path.dirname(CURR_FP)
 
+def process_row(row: dict, row_config: dict) -> dict:
+    new_row = OrderedDict()
+    if "category" in row_config and row_config['category']:
+        new_row['category'] = row[row_config['category']]
+    if "notes" in row_config and row_config['notes']:
+        new_row['notes'] = row[row_config['notes']]
+    if "feat_agg" in row_config and row_config['feat_agg']:
+        new_row['feat_agg'] = row_config['feat_agg']
+    if "value" in row_config and row_config['value']:
+        # value must be numeric
+        val = row[row_config['value']]
+        if type(val) not in (int, float):
+            val = pd.to_numeric(val).item()
+        new_row['value'] = val
+    return(new_row)
 
-def read_file_info(config, datadir):
+def read_file_info(config: data.config.Configuration,
+                   datadir: str) -> None:
+    """
+    Reads information from additional point based feature files, processes, validates and writes them
+    Args:
+        config: project configuration object
+        datadir: filepath for point based features
+    Returns: None, writes output directly
+
+    """
 
     points = []
     for source_config in list(config.data_source):
 
-        print("Processing {} data".format(source_config['name']))
+        print("Processing {} data".format(source_config['filename']))
         csv_file = source_config['filename']
         filepath = os.path.join(datadir, 'raw', 'supplemental', csv_file)
         if not os.path.exists(filepath):
-            raise SystemExit(csv_file + " not found, exiting")
+            # automatically check the raw/crashes directory
+            print(f"{filepath} not found, trying 'raw/crashes' directory")
+            filepath = os.path.join(datadir, 'raw', 'crashes', csv_file)
+            if not os.path.exists(filepath):
+                raise SystemExit(filepath + " not found, exiting")
 
         df = pd.read_csv(filepath, na_filter=False)
+
+        # rename columns according to source_config
+        #df.rename(columns=dict((v, k) for k, v in source_config.items()), inplace=True)
+        #if 'address' in source_config:
+        #    df['lat'] = None
+        #    df['lon'] = None
+        #    df['address'].apply(standardization_util.parse_address)
+
         rows = df.to_dict("records")
         missing = 0
         missing_date = 0
@@ -44,25 +80,27 @@ def read_file_info(config, datadir):
                     missing_date += 1
                     continue
                 date_time = standardization_util.parse_date(
-                    row[source_config['date']], config.timezone, time=time)
+                    str(row[source_config['date']]), config.timezone, time=time)
+
                 updated_row = OrderedDict([
-                    ("feature", source_config["name"]),
                     ("date", date_time),
                     ("location", OrderedDict([
                         ("latitude", float(lat)),
                         ("longitude", float(lon))
                     ]))
                 ])
-                if "category" in source_config and source_config['category']:
-                    updated_row['category'] = row[source_config['category']]
-                if "notes" in source_config and source_config['notes']:
-                    updated_row['notes'] = row[source_config['notes']]
-                if "feat_agg" in source_config and source_config['feat_agg']:
-                    updated_row['feat_agg'] = source_config['feat_agg']
-                if "value" in source_config and source_config['value']:
-                    updated_row['value'] = row[source_config['value']]
 
-                points.append(updated_row)
+                # process for multiple features
+                if 'feats' in source_config:
+                    for feat in source_config['feats']:
+                        updated_row['feature'] = feat['name']
+                        feat_row = process_row(row, feat)
+                        feat_row.update(updated_row)
+                        points.append(feat_row)
+                else:
+                    updated_row['feature'] = source_config['name']
+                    updated_row.update(process_row(row, source_config))
+                    points.append(updated_row)
             else:
                 missing += 1
 

--- a/src/data_standardization/standardize_point_data.py
+++ b/src/data_standardization/standardize_point_data.py
@@ -9,20 +9,27 @@ CURR_FP = os.path.dirname(
     os.path.abspath(__file__))
 BASE_FP = os.path.dirname(CURR_FP)
 
-def process_row(row: dict, row_config: dict) -> dict:
+def process_row(row: dict, row_config: dict) -> OrderedDict:
+    """
+    Function to process a row of pbf data
+    Args:
+        row: dictionary of data from pdf
+        row_config: dictionary derived from config yaml
+    Returns: dict with appropriate values
+    """
     new_row = OrderedDict()
     if "category" in row_config and row_config['category']:
         new_row['category'] = row[row_config['category']]
-    if "notes" in row_config and row_config['notes']:
-        new_row['notes'] = row[row_config['notes']]
-    if "feat_agg" in row_config and row_config['feat_agg']:
-        new_row['feat_agg'] = row_config['feat_agg']
     if "value" in row_config and row_config['value']:
         # value must be numeric
         val = row[row_config['value']]
         if type(val) not in (int, float):
             val = pd.to_numeric(val).item()
         new_row['value'] = val
+    if "notes" in row_config and row_config['notes']:
+        new_row['notes'] = row[row_config['notes']]
+    if "feat_agg" in row_config and row_config['feat_agg']:
+        new_row['feat_agg'] = row_config['feat_agg']
     return(new_row)
 
 def read_file_info(config: data.config.Configuration,
@@ -50,13 +57,6 @@ def read_file_info(config: data.config.Configuration,
                 raise SystemExit(filepath + " not found, exiting")
 
         df = pd.read_csv(filepath, na_filter=False)
-
-        # rename columns according to source_config
-        #df.rename(columns=dict((v, k) for k, v in source_config.items()), inplace=True)
-        #if 'address' in source_config:
-        #    df['lat'] = None
-        #    df['lon'] = None
-        #    df['address'].apply(standardization_util.parse_address)
 
         rows = df.to_dict("records")
         missing = 0

--- a/src/data_standardization/tests/test_standardization_util.py
+++ b/src/data_standardization/tests/test_standardization_util.py
@@ -52,7 +52,7 @@ def test_parse_date():
         '2009-01-08T08:53:00.000Z', timezone) == '2009-01-08T03:53:00-05:00'
 
     assert standardization_util.parse_date(
-        '2009', timezone) == '2009-12-30T00:00:00-05:00'
+        '2009', timezone)[:4] == '2009'
 
 
 def test_parse_address():

--- a/src/data_standardization/tests/test_standardization_util.py
+++ b/src/data_standardization/tests/test_standardization_util.py
@@ -51,6 +51,9 @@ def test_parse_date():
     assert standardization_util.parse_date(
         '2009-01-08T08:53:00.000Z', timezone) == '2009-01-08T03:53:00-05:00'
 
+    assert standardization_util.parse_date(
+        '2009', timezone) == '2009-12-30T00:00:00-05:00'
+
 
 def test_parse_address():
 

--- a/src/data_standardization/tests/test_standardize_crashes.py
+++ b/src/data_standardization/tests/test_standardize_crashes.py
@@ -391,3 +391,9 @@ def test_add_city_specific_fields():
     assert result['pedestrian'] == 1
     assert 'vehicle' not in result
     assert 'bike' not in result
+
+def test_validate_coords():
+    example = {'a': 90.0,
+               'b': -100.0}
+    assert standardize_crashes.validate_coords(example, 'a', 'b') == (90.0, -100.0)
+    assert standardize_crashes.validate_coords(example, 'b', 'a')[0] is None

--- a/src/data_standardization/tests/test_standardize_crashes.py
+++ b/src/data_standardization/tests/test_standardize_crashes.py
@@ -396,4 +396,4 @@ def test_validate_coords():
     example = {'a': 90.0,
                'b': -100.0}
     assert standardize_crashes.validate_coords(example, 'a', 'b') == (90.0, -100.0)
-    assert standardize_crashes.validate_coords(example, 'b', 'a')[0] is None
+    assert standardize_crashes.validate_coords(example, 'b', 'a') is None

--- a/src/data_standardization/tests/test_standardize_point_data.py
+++ b/src/data_standardization/tests/test_standardize_point_data.py
@@ -27,13 +27,13 @@ def test_read_file_info_default(tmpdir):
         'Ticket Issue Date': '09/02/2014',
         'Issue Time': '9:10 AM',
         'Location': "1100 CAMBRIDGE ST\nCambridge, MA\n" +
-                    "(42.37304187600046, -71.09569369699966)",
+        "(42.37304187600046, -71.09569369699966)",
         'Violation Description': 'METER EXPIRED',
     }, {
         'Ticket Issue Date': '01/09/2014',
         'Issue Time': '9:33 AM',
         'Location': "CAMBRIDGE ST / OAKLAND ST\n" +
-                    "Cambridge, MA\n(42.374105433000466, -71.12219272199962)",
+        "Cambridge, MA\n(42.374105433000466, -71.12219272199962)",
         'Violation Description': 'HYDRANT WITHIN 10 FT',
     }]
     tmppath = create_test_csv(test, tmpdir, 'test.csv')

--- a/src/data_standardization/tests/test_standardize_point_data.py
+++ b/src/data_standardization/tests/test_standardize_point_data.py
@@ -8,7 +8,7 @@ from .. import standardize_point_data
 
 def create_test_csv(test_list, tmpdir, filename):
     tmppath = tmpdir.strpath
-    
+
     os.makedirs(os.path.join(tmpdir, 'raw'))
     os.makedirs(os.path.join(tmpdir, 'raw', 'supplemental'))
     os.makedirs(os.path.join(tmpdir, 'standardized'))
@@ -23,18 +23,17 @@ def create_test_csv(test_list, tmpdir, filename):
 
 
 def test_read_file_info_default(tmpdir):
-
     test = [{
         'Ticket Issue Date': '09/02/2014',
         'Issue Time': '9:10 AM',
         'Location': "1100 CAMBRIDGE ST\nCambridge, MA\n" +
-        "(42.37304187600046, -71.09569369699966)",
+                    "(42.37304187600046, -71.09569369699966)",
         'Violation Description': 'METER EXPIRED',
     }, {
         'Ticket Issue Date': '01/09/2014',
         'Issue Time': '9:33 AM',
         'Location': "CAMBRIDGE ST / OAKLAND ST\n" +
-        "Cambridge, MA\n(42.374105433000466, -71.12219272199962)",
+                    "Cambridge, MA\n(42.374105433000466, -71.12219272199962)",
         'Violation Description': 'HYDRANT WITHIN 10 FT',
     }]
     tmppath = create_test_csv(test, tmpdir, 'test.csv')
@@ -60,7 +59,7 @@ def test_read_file_info_default(tmpdir):
     with open(config_filename, "w") as f:
         ruamel.yaml.round_trip_dump(config_dict, f)
     config = data.config.Configuration(config_filename)
-    
+
     standardize_point_data.read_file_info(config, tmppath)
     filename = os.path.join(tmppath, 'standardized', 'points.json')
     with open(filename) as data_file:
@@ -74,7 +73,7 @@ def test_read_file_info_default(tmpdir):
             'longitude': -71.09569369699966
         },
         'category': 'METER EXPIRED'
-        },
+    },
         {
             'feature': 'test',
             'date': '2014-01-09T09:33:00-05:00',
@@ -139,14 +138,88 @@ def test_read_file_info_agg(tmpdir):
         },
         'feat_agg': 'latest',
         'value': 87081
-        },
+    },
         {
-        'feature': 'aggtest',
-        'date': '2012-05-01T20:00:00-04:00',
-        'location': {
-            'latitude': 39.90415873,
-            'longitude': -75.19348751
-        },
-        'feat_agg': 'latest',
-        'value': 87679
+            'feature': 'aggtest',
+            'date': '2012-05-01T20:00:00-04:00',
+            'location': {
+                'latitude': 39.90415873,
+                'longitude': -75.19348751
+            },
+            'feat_agg': 'latest',
+            'value': 87679
         }]
+
+
+def test_read_file_info_multi(tmpdir):
+    test = [{
+        'SETDATE': '2012-03-15T00:00:00.000Z',
+        'LATITUDE': '39.74391',
+        'LONGITUDE': '-75.22693',
+        'RECORDNUM': '87081'
+    }, {
+        'SETDATE': '2012-05-02T00:00:00.000Z',
+        'LATITUDE': '39.90415873',
+        'LONGITUDE': '-75.19348751',
+        'RECORDNUM': '87679'
+    }]
+    tmppath = create_test_csv(test, tmpdir, 'test_multi.csv')
+
+    config_dict = {
+        'name': 'cambridge',
+        'city_latitude': 42.3600825,
+        'city_longitude': -71.0588801,
+        'city_radius': 15,
+        'crashes_files': {'test': {}},
+        'city': "Cambridge, Massachusetts, USA",
+        'timezone': "America/New_York",
+        'data_source': [{
+            'name': 'aggtest',
+            'filename': 'test_multi.csv',
+            'latitude': 'LATITUDE',
+            'longitude': 'LONGITUDE',
+            'date': 'SETDATE',
+            'feats': [{
+                'name': 'test_value',
+                'feat_agg': 'latest',
+                'value': 'RECORDNUM'
+            },
+                {'name': 'test_count'
+                 }
+            ]
+        }]
+    }
+
+    config_filename = os.path.join(tmpdir, 'test.yml')
+    with open(config_filename, "w") as f:
+        ruamel.yaml.round_trip_dump(config_dict, f)
+    config = data.config.Configuration(config_filename)
+
+    standardize_point_data.read_file_info(config, tmppath)
+    filename = os.path.join(tmppath, 'standardized', 'points.json')
+    with open(filename) as data_file:
+        result = json.load(data_file)
+    assert result == [{'feature': 'test_value',
+                   'feat_agg': 'latest',
+                   'value': 87081,
+                   'date': '2012-03-14T20:00:00-04:00',
+                   'location': {
+                       'latitude': 39.74391,
+                       'longitude': -75.22693000000001}},
+                  {'feature': 'test_count',
+                   'date': '2012-03-14T20:00:00-04:00',
+                   'location': {
+                       'latitude': 39.74391,
+                       'longitude': -75.22693000000001}},
+                  {'feature': 'test_value',
+                   'feat_agg': 'latest',
+                   'value': 87679,
+                   'date': '2012-05-01T20:00:00-04:00',
+                   'location': {
+                       'latitude': 39.90415873,
+                       'longitude': -75.19348751}},
+                  {'feature': 'test_count',
+                   'date': '2012-05-01T20:00:00-04:00',
+                   'location': {
+                       'latitude': 39.90415873,
+                       'longitude': -75.19348751}}]

--- a/src/features/make_canon_dataset.py
+++ b/src/features/make_canon_dataset.py
@@ -1,7 +1,7 @@
 
 # coding: utf-8
-# Generate canonical dataset for hackathon
-# Developed by: bpben
+# Generate canonical dataset
+# Developed by: bpben, j-t-t
 import json
 import pandas as pd
 from data.util import read_geojson
@@ -56,7 +56,7 @@ def read_records(fp, id_col, split_columns=[]):
     return(df_g)
 
 
-def road_make(feats, fp):
+def road_make(feats: list, fp: str) -> pd.DataFrame:
     """ Makes road feature df, intersections + non-intersections
     Args:
         feats - list of features to be included
@@ -69,7 +69,9 @@ def road_make(feats, fp):
     print("reading ", fp)
     segments = read_geojson(fp)
     df = pd.DataFrame([x.properties for x in segments])
-
+    # need to enforce id to string
+    # TODO: This id as string issue is always a problem, we need to fix that
+    df['id'] = df['id'].astype(str)
     df.set_index('id', inplace=True)
 
     # Check for missing features
@@ -85,7 +87,7 @@ def road_make(feats, fp):
     return df[feats]
 
 
-def aggregate_roads(feats, datadir, split_columns):
+def aggregate_roads(feats: list, datadir: str, split_columns: list):
 
     # read/aggregate crashes
     crash = read_records(

--- a/src/features/tests/test_make_canon.py
+++ b/src/features/tests/test_make_canon.py
@@ -40,7 +40,7 @@ def test_aggregate_roads():
 
     assert pd.api.types.infer_dtype(cr_con_roads.segment_id) == 'string'
     assert cr_con_roads.columns.tolist() == expected_columns
-    assert cr_con_roads.shape == (17, 11)
+    assert cr_con_roads.shape == (14, 11)
     
 
 def test_road_make():
@@ -56,12 +56,12 @@ def test_road_make():
 
     expected = pd.DataFrame({
         'id': ['000', '001', '002', '003', '004', '005', '006',
-               '007', '008', '009', 0, 1, 2, 3],
+               '007', '008', '009', '0', '1', '2', '3'],
         'width': [24, 24, 24, 15, 15, 24, 5, 24, 12, 12, 24, 24, 24, 24],
         'lanes': [2, 3, 3, 3, 3, 2, 1, 2, 1, 1, 2, 3, 3, 3],
         'hwy_type': [6, 6, 6, 3, 6, 6, 1, 6, 1, 1, 1, 1, 3, 1],
         'osm_speed': [0, 0, 0, 0, 25, 0, 25, 0, 25, 25, 25, 25, 25, 25]
     })
     expected.set_index('id', inplace=True)
-    assert expected.equals(result)
+    pd.testing.assert_frame_equal(expected, result)
 

--- a/src/features/tests/test_make_canon.py
+++ b/src/features/tests/test_make_canon.py
@@ -32,10 +32,15 @@ def test_aggregate_roads():
         DATA_FP,
         ['bike', 'pedestrian', 'vehicle']
     )
+    expected_columns = ['width', 'lanes', 'hwy_type', 'osm_speed', 'signal', 'oneway',
+       'segment_id', 'crash', 'bike', 'pedestrian', 'vehicle']
 
     cr_con_roads = make_canon_dataset.combine_crash_with_segments(
         cr_con, aggregated)
-#    assert len(cr_con_roads.year.unique()) == 2
+
+    assert pd.api.types.infer_dtype(cr_con_roads.segment_id) == 'string'
+    assert cr_con_roads.columns.tolist() == expected_columns
+    assert cr_con_roads.shape == (17, 11)
     
 
 def test_road_make():

--- a/src/features/tests/test_make_canon.py
+++ b/src/features/tests/test_make_canon.py
@@ -28,19 +28,23 @@ def test_read_records(tmpdir):
 def test_aggregate_roads():
 
     aggregated, cr_con = make_canon_dataset.aggregate_roads(
-        ['width', 'lanes', 'hwy_type', 'osm_speed', 'signal', 'oneway'],
+        ['width', 'lanes', 'hwy_type', 'signal', 'oneway'],
+        ['osm_speed'],
         DATA_FP,
         ['bike', 'pedestrian', 'vehicle']
     )
-    expected_columns = ['width', 'lanes', 'hwy_type', 'osm_speed', 'signal', 'oneway',
-       'segment_id', 'crash', 'bike', 'pedestrian', 'vehicle']
+    expected_columns = set(['width', 'lanes', 'hwy_type', 'osm_speed', 'signal', 'oneway',
+       'segment_id', 'crash', 'bike', 'pedestrian', 'vehicle'])
+
+    expected_width = [24, 24, 24, 15, 15, 24, 5, 24, 12, 12, 24, 24, 24, 24]
 
     cr_con_roads = make_canon_dataset.combine_crash_with_segments(
         cr_con, aggregated)
 
     assert pd.api.types.infer_dtype(cr_con_roads.segment_id) == 'string'
-    assert cr_con_roads.columns.tolist() == expected_columns
+    assert set(cr_con_roads.columns.tolist()) == expected_columns
     assert cr_con_roads.shape == (14, 11)
+    assert cr_con_roads.width.tolist() == [24, 24, 24, 15, 15, 24, 5, 24, 12, 12, 24, 24, 24, 24]
     
 
 def test_road_make():

--- a/src/initialize_city.py
+++ b/src/initialize_city.py
@@ -75,26 +75,33 @@ def write_default_features(f, waze=False, supplemental=[],
 
     if supplemental:
         f.write(
-            "# Additional data sources\n" +
+            "# Additional point based features sources\n" +
             "# Any csv file with rows corresponding to location points\n" +
+            "# See README for details on format (https://github.com/insight-lane/crash-model/tree/master/src#point-based-features)\n" +
             "data_source:\n"
         )
 
         for filename in supplemental:
             f.write(
-                "  - name: \n" +
-                "    filename: {}\n".format(filename) +
+                " copy-paste the block below for each additional data source\n" +
+                "  - filename: {}\n".format(filename) +
+                "    # Provide either lat/long or address (address will be geocoded): \n" +
+                "    latitude: \n" +
+                "    longitude: \n" +
                 "    address: \n" +
                 "    date: \n" +
                 "    time: \n" +
-                "    category: \n" +
-                "    notes: \n" +
-                "    # Feature is 'categorical' or 'continuous'\n" +
-                "    feat: \n" +
-                "    # feat_agg (feature aggregation) can be total count 'default' or 'latest value' \n" +
-                "    feat_agg: \n"
-                "    # if latest, the column name where the value can be found \n" +
-                "    value: \n"
+                "    feats: \n" +
+                "    # copy-paste the block below for each additional feature for this file\n" +
+                "      - name: \n" +
+                "        category: \n" +
+                "        notes: \n" +
+                "        # Feature is 'categorical' or 'continuous' (numeric), default is continuous'\n" +
+                "        feat_type: \n" +
+                "        # feat_agg (feature aggregation), only option is 'latest' (latest value), default is count\n" +
+                "        feat_agg: \n"
+                "        # if 'latest' above, provide column name where the value can be found \n" +
+                "        value: \n"
                 )
         f.write("\n")
 

--- a/src/models/tests/test_train_model.py
+++ b/src/models/tests/test_train_model.py
@@ -57,8 +57,8 @@ def test_process_features(tmpdir):
     f_cont = ['width', 'jam_percent']
     features = ['signal', 'lanes', 'width', 'jam_percent']
     test_data, features, lm_features = train_model.process_features(features, f_cat, f_cont, test_data)
-    assert set(features) == set(['intersection', 'signal1', 'signal0', 'log_width', 'lanes2', 'lanes1'])
-    assert set(lm_features) == set(['intersection', 'signal1', 'log_width', 'lanes2'])
+    assert set(features) == set(['intersection', 'signal_1', 'signal_0', 'log_width', 'lanes_2', 'lanes_1'])
+    assert set(lm_features) == set(['intersection', 'signal_1', 'log_width', 'lanes_2'])
     
 
 def test_initialize_and_run(tmpdir):


### PR DESCRIPTION
Main thing trying to do here - enable a config to specify that there are multiple point-based features in one file (rather than repeating the information again for each feature).  

There are also some documentation updates here, part of ongoing process

Also - noticed a major issue with how crashes were being joined to segments related to segment_ids being mixed types.  Should now be fixed.